### PR TITLE
Cleaning up storage_default_object_acl

### DIFF
--- a/google/resource_storage_default_object_acl.go
+++ b/google/resource_storage_default_object_acl.go
@@ -26,46 +26,36 @@ func resourceStorageDefaultObjectAcl() *schema.Resource {
 				Type:     schema.TypeList,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				MinItems: 1,
 			},
 		},
 	}
-}
-
-func getDefaultObjectAclId(bucket string) string {
-	return bucket + "-default-object-acl"
 }
 
 func resourceStorageDefaultObjectAclCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
 	bucket := d.Get("bucket").(string)
-	role_entity := make([]interface{}, 0)
+	roleEntity := d.Get("role_entity").([]interface{})
 
-	if v, ok := d.GetOk("role_entity"); ok {
-		role_entity = v.([]interface{})
-	}
+	for _, v := range roleEntity {
+		pair, err := getRoleEntityPair(v.(string))
 
-	if len(role_entity) > 0 {
-		for _, v := range role_entity {
-			pair, err := getRoleEntityPair(v.(string))
-
-			ObjectAccessControl := &storage.ObjectAccessControl{
-				Role:   pair.Role,
-				Entity: pair.Entity,
-			}
-
-			log.Printf("[DEBUG]: setting role = %s, entity = %s on bucket %s", pair.Role, pair.Entity, bucket)
-
-			_, err = config.clientStorage.DefaultObjectAccessControls.Insert(bucket, ObjectAccessControl).Do()
-
-			if err != nil {
-				return fmt.Errorf("Error setting Default Object ACL for %s on bucket %s: %v", pair.Entity, bucket, err)
-			}
+		ObjectAccessControl := &storage.ObjectAccessControl{
+			Role:   pair.Role,
+			Entity: pair.Entity,
 		}
 
-		return resourceStorageDefaultObjectAclRead(d, meta)
+		log.Printf("[DEBUG]: setting role = %s, entity = %s on bucket %s", pair.Role, pair.Entity, bucket)
+
+		_, err = config.clientStorage.DefaultObjectAccessControls.Insert(bucket, ObjectAccessControl).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error setting Default Object ACL for %s on bucket %s: %v", pair.Entity, bucket, err)
+		}
 	}
-	return nil
+	d.SetId(bucket)
+	return resourceStorageDefaultObjectAclRead(d, meta)
 }
 
 func resourceStorageDefaultObjectAclRead(d *schema.ResourceData, meta interface{}) error {
@@ -73,41 +63,38 @@ func resourceStorageDefaultObjectAclRead(d *schema.ResourceData, meta interface{
 
 	bucket := d.Get("bucket").(string)
 
-	if _, ok := d.GetOk("role_entity"); ok {
-		role_entity := make([]interface{}, 0)
-		re_local := d.Get("role_entity").([]interface{})
-		re_local_map := make(map[string]string)
-		for _, v := range re_local {
-			res, err := getRoleEntityPair(v.(string))
-
-			if err != nil {
-				return fmt.Errorf(
-					"Old state has malformed Role/Entity pair: %v", err)
-			}
-
-			re_local_map[res.Entity] = res.Role
-		}
-
-		res, err := config.clientStorage.DefaultObjectAccessControls.List(bucket).Do()
+	roleEntities := make([]interface{}, 0)
+	reLocal := d.Get("role_entity").([]interface{})
+	reLocalMap := make(map[string]string)
+	for _, v := range reLocal {
+		res, err := getRoleEntityPair(v.(string))
 
 		if err != nil {
-			return handleNotFoundError(err, d, fmt.Sprintf("Storage Default Object ACL for bucket %q", d.Get("bucket").(string)))
+			return fmt.Errorf(
+				"Old state has malformed Role/Entity pair: %v", err)
 		}
 
-		for _, v := range res.Items {
-			role := v.Role
-			entity := v.Entity
-			// We only store updates to the locally defined access controls
-			if _, in := re_local_map[entity]; in {
-				role_entity = append(role_entity, fmt.Sprintf("%s:%s", role, entity))
-				log.Printf("[DEBUG]: saving re %s-%s", v.Role, v.Entity)
-			}
-		}
-
-		d.Set("role_entity", role_entity)
+		reLocalMap[res.Entity] = res.Role
 	}
 
-	d.SetId(getDefaultObjectAclId(bucket))
+	res, err := config.clientStorage.DefaultObjectAccessControls.List(bucket).Do()
+
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Storage Default Object ACL for bucket %q", d.Get("bucket").(string)))
+	}
+
+	for _, v := range res.Items {
+		role := v.Role
+		entity := v.Entity
+		// We only store updates to the locally defined access controls
+		if _, in := reLocalMap[entity]; in {
+			roleEntities = append(roleEntities, fmt.Sprintf("%s:%s", role, entity))
+			log.Printf("[DEBUG]: saving re %s-%s", v.Role, v.Entity)
+		}
+	}
+
+	d.Set("role_entity", roleEntities)
+
 	return nil
 }
 
@@ -116,62 +103,61 @@ func resourceStorageDefaultObjectAclUpdate(d *schema.ResourceData, meta interfac
 
 	bucket := d.Get("bucket").(string)
 
-	if d.HasChange("role_entity") {
-		o, n := d.GetChange("role_entity")
-		old_re := o.([]interface{})
-		new_re := n.([]interface{})
+	if !d.HasChange("role_entity") {
+		return nil
+	}
+	o, n := d.GetChange("role_entity")
+	oldRe := o.([]interface{})
+	newRe := n.([]interface{})
 
-		old_re_map := make(map[string]string)
-		for _, v := range old_re {
-			res, err := getRoleEntityPair(v.(string))
+	oldReMap := make(map[string]string)
+	for _, v := range oldRe {
+		res, err := getRoleEntityPair(v.(string))
 
-			if err != nil {
-				return fmt.Errorf(
-					"Old state has malformed Role/Entity pair: %v", err)
-			}
-
-			old_re_map[res.Entity] = res.Role
+		if err != nil {
+			return fmt.Errorf(
+				"Old state has malformed Role/Entity pair: %v", err)
 		}
 
-		for _, v := range new_re {
-			pair, err := getRoleEntityPair(v.(string))
-
-			ObjectAccessControl := &storage.ObjectAccessControl{
-				Role:   pair.Role,
-				Entity: pair.Entity,
-			}
-
-			// If the old state is missing for this entity, it needs to
-			// be created. Otherwise it is updated
-			if _, ok := old_re_map[pair.Entity]; ok {
-				_, err = config.clientStorage.DefaultObjectAccessControls.Update(
-					bucket, pair.Entity, ObjectAccessControl).Do()
-			} else {
-				_, err = config.clientStorage.DefaultObjectAccessControls.Insert(
-					bucket, ObjectAccessControl).Do()
-			}
-
-			// Now we only store the keys that have to be removed
-			delete(old_re_map, pair.Entity)
-
-			if err != nil {
-				return fmt.Errorf("Error updating Storage Default Object ACL for bucket %s: %v", bucket, err)
-			}
-		}
-
-		for entity, _ := range old_re_map {
-			log.Printf("[DEBUG]: removing entity %s", entity)
-			err := config.clientStorage.DefaultObjectAccessControls.Delete(bucket, entity).Do()
-
-			if err != nil {
-				return fmt.Errorf("Error updating Storage Default Object ACL for bucket %s: %v", bucket, err)
-			}
-		}
-
-		return resourceStorageDefaultObjectAclRead(d, meta)
+		oldReMap[res.Entity] = res.Role
 	}
 
-	return nil
+	for _, v := range newRe {
+		pair, err := getRoleEntityPair(v.(string))
+
+		ObjectAccessControl := &storage.ObjectAccessControl{
+			Role:   pair.Role,
+			Entity: pair.Entity,
+		}
+
+		// If the old state is present for the  entity, it is updated
+		// If the old state is missing, it is inserted
+		if _, ok := oldReMap[pair.Entity]; ok {
+			_, err = config.clientStorage.DefaultObjectAccessControls.Update(
+				bucket, pair.Entity, ObjectAccessControl).Do()
+		} else {
+			_, err = config.clientStorage.DefaultObjectAccessControls.Insert(
+				bucket, ObjectAccessControl).Do()
+		}
+
+		// Now we only store the keys that have to be removed
+		delete(oldReMap, pair.Entity)
+
+		if err != nil {
+			return fmt.Errorf("Error updating Storage Default Object ACL for bucket %s: %v", bucket, err)
+		}
+	}
+
+	for entity := range oldReMap {
+		log.Printf("[DEBUG]: removing entity %s", entity)
+		err := config.clientStorage.DefaultObjectAccessControls.Delete(bucket, entity).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error updating Storage Default Object ACL for bucket %s: %v", bucket, err)
+		}
+	}
+
+	return resourceStorageDefaultObjectAclRead(d, meta)
 }
 
 func resourceStorageDefaultObjectAclDelete(d *schema.ResourceData, meta interface{}) error {
@@ -179,8 +165,8 @@ func resourceStorageDefaultObjectAclDelete(d *schema.ResourceData, meta interfac
 
 	bucket := d.Get("bucket").(string)
 
-	re_local := d.Get("role_entity").([]interface{})
-	for _, v := range re_local {
+	reLocal := d.Get("role_entity").([]interface{})
+	for _, v := range reLocal {
 		res, err := getRoleEntityPair(v.(string))
 		if err != nil {
 			return err

--- a/google/resource_storage_default_object_acl_test.go
+++ b/google/resource_storage_default_object_acl_test.go
@@ -19,7 +19,7 @@ func TestAccGoogleStorageDefaultObjectAcl_basic(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageDefaultObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageDefaultObjectsAclBasic1(bucketName),
+				Config: testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntityBasic1, roleEntityBasic2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic1),
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic2),
@@ -40,7 +40,7 @@ func TestAccGoogleStorageDefaultObjectAcl_upgrade(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageDefaultObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageDefaultObjectsAclBasic1(bucketName),
+				Config: testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntityBasic1, roleEntityBasic2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic1),
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic2),
@@ -48,7 +48,7 @@ func TestAccGoogleStorageDefaultObjectAcl_upgrade(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageDefaultObjectsAclBasic2(bucketName),
+				Config: testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntityBasic2, roleEntityBasic3_owner),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic2),
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic3_owner),
@@ -56,9 +56,9 @@ func TestAccGoogleStorageDefaultObjectAcl_upgrade(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageDefaultObjectsAclBasicDelete(bucketName),
+				Config: testGoogleStorageDefaultObjectsAclBasicDelete(bucketName, roleEntityBasic1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageDefaultObjectAclDelete(bucketName, roleEntityBasic1),
+					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic1),
 					testAccCheckGoogleStorageDefaultObjectAclDelete(bucketName, roleEntityBasic2),
 					testAccCheckGoogleStorageDefaultObjectAclDelete(bucketName, roleEntityBasic3_reader),
 				),
@@ -78,7 +78,7 @@ func TestAccGoogleStorageDefaultObjectAcl_downgrade(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageDefaultObjectAclDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageDefaultObjectsAclBasic2(bucketName),
+				Config: testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntityBasic2, roleEntityBasic3_owner),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic2),
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic3_owner),
@@ -86,7 +86,7 @@ func TestAccGoogleStorageDefaultObjectAcl_downgrade(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageDefaultObjectsAclBasic3(bucketName),
+				Config: testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntityBasic2, roleEntityBasic3_reader),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic2),
 					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic3_reader),
@@ -94,9 +94,9 @@ func TestAccGoogleStorageDefaultObjectAcl_downgrade(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testGoogleStorageDefaultObjectsAclBasicDelete(bucketName),
+				Config: testGoogleStorageDefaultObjectsAclBasicDelete(bucketName, roleEntityBasic1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleStorageDefaultObjectAclDelete(bucketName, roleEntityBasic1),
+					testAccCheckGoogleStorageDefaultObjectAcl(bucketName, roleEntityBasic1),
 					testAccCheckGoogleStorageDefaultObjectAclDelete(bucketName, roleEntityBasic2),
 					testAccCheckGoogleStorageDefaultObjectAclDelete(bucketName, roleEntityBasic3_reader),
 				),
@@ -160,7 +160,7 @@ func testAccCheckGoogleStorageDefaultObjectAclDelete(bucket, roleEntityS string)
 	}
 }
 
-func testGoogleStorageDefaultObjectsAclBasicDelete(bucketName string) string {
+func testGoogleStorageDefaultObjectsAclBasicDelete(bucketName, roleEntity string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
@@ -168,25 +168,12 @@ resource "google_storage_bucket" "bucket" {
 
 resource "google_storage_default_object_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
-	role_entity = []
+	role_entity = ["%s"]
 }
-`, bucketName)
-}
-
-func testGoogleStorageDefaultObjectsAclBasic1(bucketName string) string {
-	return fmt.Sprintf(`
-resource "google_storage_bucket" "bucket" {
-	name = "%s"
+`, bucketName, roleEntity)
 }
 
-resource "google_storage_default_object_acl" "acl" {
-	bucket = "${google_storage_bucket.bucket.name}"
-	role_entity = ["%s", "%s"]
-}
-`, bucketName, roleEntityBasic1, roleEntityBasic2)
-}
-
-func testGoogleStorageDefaultObjectsAclBasic2(bucketName string) string {
+func testGoogleStorageDefaultObjectsAclBasic(bucketName, roleEntity1, roleEntity2 string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
@@ -196,18 +183,5 @@ resource "google_storage_default_object_acl" "acl" {
 	bucket = "${google_storage_bucket.bucket.name}"
 	role_entity = ["%s", "%s"]
 }
-`, bucketName, roleEntityBasic2, roleEntityBasic3_owner)
-}
-
-func testGoogleStorageDefaultObjectsAclBasic3(bucketName string) string {
-	return fmt.Sprintf(`
-resource "google_storage_bucket" "bucket" {
-	name = "%s"
-}
-
-resource "google_storage_default_object_acl" "acl" {
-	bucket = "${google_storage_bucket.bucket.name}"
-	role_entity = ["%s", "%s"]
-}
-`, bucketName, roleEntityBasic2, roleEntityBasic3_reader)
+`, bucketName, roleEntity1, roleEntity2)
 }

--- a/website/docs/r/storage_default_object_acl.html.markdown
+++ b/website/docs/r/storage_default_object_acl.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # google\_storage\_default\_object\_acl
 
-Creates a new default object ACL in Google cloud storage service (GCS). For more information see 
+Creates a new default object ACL in Google Cloud Storage service (GCS). For more information see
 [the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
 and 
 [API](https://cloud.google.com/storage/docs/json_api/v1/defaultObjectAccessControls).


### PR DESCRIPTION
Complying with review [ here](Add google_storage_default_object_acl resource #992)

Using mixedCaps for variable names
Cleaning up repetitions in test resources
Setting up MinItems: 1 for 'role_entity' field 
Removing unnecessary checks for role_entity being set, since it's a  required field
Removing suffix from the resource id, and using 'bucket' as resource id

