### PR TITLE
Support `distributionPolicy` when creating regional instance group managers.

### DIFF
--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -204,6 +204,32 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	})
 }
 
+func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
+	t.Parallel()
+
+	var manager computeBeta.InstanceGroupManager
+
+	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	zones := []string{"zones/europe-west3-a", "zones/europe-west3-b"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRegionInstanceGroupManager_distributionPolicy(template, igm, zones),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRegionInstanceGroupManagerBetaExists(
+						"google_compute_region_instance_group_manager.igm-basic", &manager),
+					testAccCheckRegionInstanceGroupManagerDistributionPolicy("google_compute_region_instance_group_manager.igm-basic", zones),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckRegionInstanceGroupManagerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -397,6 +423,51 @@ func testAccCheckRegionInstanceGroupManagerAutoHealingPolicies(n, hck string, in
 		if autoHealingPolicy.InitialDelaySec != initialDelaySec {
 			return fmt.Errorf("Expected auto healing policy inital delay to be %d, got %d", initialDelaySec, autoHealingPolicy.InitialDelaySec)
 		}
+		return nil
+	}
+}
+
+func testAccCheckRegionInstanceGroupManagerDistributionPolicy(n string, zones []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		manager, err := config.clientComputeBeta.RegionInstanceGroupManagers.Get(
+			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if manager.DistributionPolicy == nil {
+			return fmt.Errorf("Expected distribution policy to exist")
+		}
+
+		zoneConfigs := manager.DistributionPolicy.Zones
+		if len(zoneConfigs) != len(zones) {
+			return fmt.Errorf("Expected number of zones in distribution policy to match; had %d, expected %d", len(zoneConfigs), len(zones))
+		}
+
+		sort.Strings(zones)
+		sortedExisting := make([]string, 0)
+		for _, zone := range zoneConfigs {
+			sortedExisting = append(sortedExisting, zone.Zone)
+		}
+		sort.Strings(sortedExisting)
+
+		for i := 0; i < len(zones); i++ {
+			if sortedExisting[i] != zones[i] {
+				return fmt.Errorf("found mismatched zone configuration: expected entry #%d as '%s', got %s", i, zones[i], sortedExisting[i])
+			}
+		}
+
 		return nil
 	}
 }
@@ -797,4 +868,39 @@ resource "google_compute_http_health_check" "zero" {
 	timeout_sec        = 1
 }
 	`, template, target, igm, hck)
+}
+
+func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
+	return fmt.Sprintf(`
+resource "google_compute_instance_template" "igm-basic" {
+	name = "%s"
+	machine_type = "n1-standard-1"
+	can_ip_forward = false
+	tags = ["foo", "bar"]
+	disk {
+		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		auto_delete = true
+		boot = true
+	}
+	network_interface {
+		network = "default"
+	}
+	metadata {
+		foo = "bar"
+	}
+	service_account {
+		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
+	}
+}
+
+resource "google_compute_region_instance_group_manager" "igm-basic" {
+	description = "Terraform test instance group manager"
+	name = "%s"
+	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+	base_instance_name = "igm-basic"
+	region = "us-central1"
+	target_size = 2
+	distribution_policy = ["%s"]
+}
+	`, template, igm, strings.Join(zones, "\",\""))
 }

--- a/google/resource_compute_region_instance_group_manager_test.go
+++ b/google/resource_compute_region_instance_group_manager_test.go
@@ -211,7 +211,7 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-	zones := []string{"zones/europe-west3-a", "zones/europe-west3-b"}
+	zones := []string{"us-central1-a", "us-central1-b"}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -463,7 +463,7 @@ func testAccCheckRegionInstanceGroupManagerDistributionPolicy(n string, zones []
 		sort.Strings(sortedExisting)
 
 		for i := 0; i < len(zones); i++ {
-			if sortedExisting[i] != zones[i] {
+			if !strings.HasSuffix(sortedExisting[i], zones[i]) {
 				return fmt.Errorf("found mismatched zone configuration: expected entry #%d as '%s', got %s", i, zones[i], sortedExisting[i])
 			}
 		}
@@ -887,9 +887,6 @@ resource "google_compute_instance_template" "igm-basic" {
 	}
 	metadata {
 		foo = "bar"
-	}
-	service_account {
-		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
 }
 

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -37,7 +37,7 @@ resource "google_compute_region_instance_group_manager" "appserver" {
   base_instance_name  = "app"
   instance_template   = "${google_compute_instance_template.appserver.self_link}"
   region              = "us-central1"
-  distribution_policy = ["zones/us-central1-a", "zones/us-central1-b", "zones/us-central1-f"]
+  distribution_policy = ["us-central1-a", "us-central1-f"]
 
   target_pools = ["${google_compute_target_pool.appserver.self_link}"]
   target_size  = 2

--- a/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -34,9 +34,10 @@ resource "google_compute_health_check" "autohealing" {
 resource "google_compute_region_instance_group_manager" "appserver" {
   name = "appserver-igm"
 
-  base_instance_name = "app"
-  instance_template  = "${google_compute_instance_template.appserver.self_link}"
-  region             = "us-central1"
+  base_instance_name  = "app"
+  instance_template   = "${google_compute_instance_template.appserver.self_link}"
+  region              = "us-central1"
+  distribution_policy = ["zones/us-central1-a", "zones/us-central1-b", "zones/us-central1-f"]
 
   target_pools = ["${google_compute_target_pool.appserver.self_link}"]
   target_size  = 2
@@ -98,6 +99,10 @@ The following arguments are supported:
 
 * `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
+
+* `distribution_policy` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The distribution policy for this managed instance
+group. You can specify one or more values. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups#selectingzones).
+
 
 The `named_port` block supports: (Include a `named_port` block for each named-port required).
 


### PR DESCRIPTION
This allows regional IGMs to specify precisely which zones that instances should be launched into.

This addresses issue #549.