### PR TITLE
Support for rolling update functionality

### DIFF
--- a/google/resource_compute_instance_group_manager.go
+++ b/google/resource_compute_instance_group_manager.go
@@ -825,12 +825,6 @@ func expandUpdatePolicy(configured []interface{}) *computeBeta.InstanceGroupMana
 
 		updatePolicy.MinimalAction = data["minimal_action"].(string)
 		updatePolicy.Type = data["type"].(string)
-		updatePolicy.MaxSurge = &computeBeta.FixedOrPercent{
-			Fixed: int64(data["max_surge_fixed"].(int)),
-		}
-		updatePolicy.MaxUnavailable = &computeBeta.FixedOrPercent{
-			Fixed: int64(data["max_unavailable_fixed"].(int)),
-		}
 
 		// percent and fixed values are conflicting
 		// when the percent values are set, the fixed values will be ignored
@@ -838,11 +832,19 @@ func expandUpdatePolicy(configured []interface{}) *computeBeta.InstanceGroupMana
 			updatePolicy.MaxSurge = &computeBeta.FixedOrPercent{
 				Percent: int64(v.(int)),
 			}
+		} else {
+			updatePolicy.MaxSurge = &computeBeta.FixedOrPercent{
+				Fixed: int64(data["max_surge_fixed"].(int)),
+			}
 		}
 
 		if v := data["max_unavailable_percent"]; v.(int) > 0 {
 			updatePolicy.MaxUnavailable = &computeBeta.FixedOrPercent{
 				Percent: int64(v.(int)),
+			}
+		} else {
+			updatePolicy.MaxUnavailable = &computeBeta.FixedOrPercent{
+				Fixed: int64(data["max_unavailable_fixed"].(int)),
 			}
 		}
 

--- a/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/website/docs/r/compute_instance_group_manager.html.markdown
@@ -90,8 +90,8 @@ The following arguments are supported:
 * `update_strategy` - (Optional, Default `"RESTART"`) If the `instance_template`
     resource is modified, a value of `"NONE"` will prevent any of the managed
     instances from being restarted by Terraform. A value of `"RESTART"` will
-    restart all of the instances at once. In the future, as the GCE API matures
-    we will support `"ROLLING_UPDATE"` as well.
+    restart all of the instances at once. `"ROLLING_UPDATE"` is supported as [Beta feature].
+    A value of `"ROLLING_UPDATE"` requires `rolling_update_policy` block to be set
 
 * `target_size` - (Optional) The target number of running instances for this managed
     instance group. This value should always be explicitly set unless this resource is attached to
@@ -106,13 +106,43 @@ The following arguments are supported:
 * `auto_healing_policies` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
 
-The `named_port` block supports: (Include a `named_port` block for each named-port required).
+* `rolling_update_policy` - (Optional, [Beta](/docs/providers/google/index.html#beta-features)) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/patch)
+
+The **rolling_update_policy** block supports:
+
+```hcl
+rolling_update_policy{
+  type = "PROACTIVE"
+  minimal_action = "REPLACE"
+  max_surge_percent = 20
+  max_unavailable_fixed = 2
+  min_ready_sec = 50
+}
+```
+
+* `minimal_action` - (Required) - Minimal action to be taken on an instance. Valid values are `"RESTART"`, `"REPLACE"`
+
+* `type` - (Required) - The type of update. Valid values are `"OPPORTUNISTIC"`, `"PROACTIVE"`
+
+* `max_surge_fixed` - (Optional), The maximum number of instances that can be created above the specified targetSize during the update process. Conflicts with `max_surge_percent`. If neither is set, defaults to 1
+
+* `max_surge_percent` - (Optional), The maximum number of instances(calculated as percentage) that can be created above the specified targetSize during the update process. Conflicts with `max_surge_fixed`.
+
+* `max_unavailable_fixed` - (Optional), The maximum number of instances that can be unavailable during the update process. Conflicts with `max_unavailable_percent`. If neither is set, defaults to 1
+
+* `max_unavailable_percent` - (Optional), The maximum number of instances(calculated as percentage) tthat can be unavailable during the update process. Conflicts with `max_unavailable_fixed`.
+
+* `min_ready_sec` - (Optional), Minimum number of seconds to wait for after a newly created instance becomes available. This value must be from range [0, 3600]
+- - -
+
+The **named_port** block supports: (Include a `named_port` block for each named-port required).
 
 * `name` - (Required) The name of the port.
 
 * `port` - (Required) The port number.
+- - -
 
-The `auto_healing_policies` block supports:
+The **auto_healing_policies** block supports:
 
 * `health_check` - (Required) The health check resource that signals autohealing.
 


### PR DESCRIPTION
Addresses [51](https://github.com/terraform-providers/terraform-provider-google/issues/51)

Supports beta functionality on rolling updates.

rolling_update_policy block is stored in state file only(as opposed to applying it to InstanceManager object), and is applied at patch calls only(only when the chnage requires a rolling update funcitonality. ex. changing instance template). That allows for flexibility of modifying it, as needed. If applied to InstanceManager, it can't be modified without re-creating the InstanceManager

I have also chose to have two separate arguments that are in conflict with each other for "fixed" and "percent" values. I think it's a little cleaner, since we can do appropriate validations on "Int"s and not have to convert values to appropriate types a bunch of times
As an alternative, I could consolidate them to a single argument of type string, and do regex parsing to figure out whether it's a percent value(contains '%') or fixed value(number only), but I seem to like the first approach a little better. Please, let me know what you think regarding this